### PR TITLE
Update line endings to only "\n" for Linux

### DIFF
--- a/src/zcl_prometheus.clas.abap
+++ b/src/zcl_prometheus.clas.abap
@@ -160,7 +160,7 @@ CLASS ZCL_PROMETHEUS IMPLEMENTATION.
   METHOD zif_prometheus~get_metric_string.
     DATA(records) = read_all( ).
     LOOP AT records ASSIGNING FIELD-SYMBOL(<record>).
-      r_result = r_result && |{ <record>-key } { <record>-value }\r\n|.
+      r_result = r_result && |{ <record>-key } { <record>-value }\n|.
     ENDLOOP.
   ENDMETHOD.
 


### PR DESCRIPTION
When I tried out your coding with a recent Prometheus instance (version 2.44.0 running on Debian Buster 10 Linux) I had to adjust from "\r\n" to just "\n" since otherwise the metric parsing on the Prometheus inbound side would fail.

When using it with a Prometheus on Windows then most likely "\r\n" is however required (not tested by me).

A "proper" solution might therefore be to add a new static member in the class that can be set to either "L" or "W" for Linux or Windows and then let the coding pick the corresponding line endings at runtime.